### PR TITLE
Server and client changes. Not show errors or nil results in range testing

### DIFF
--- a/src/client/DCSInsight/DCSInsight.csproj
+++ b/src/client/DCSInsight/DCSInsight.csproj
@@ -6,7 +6,7 @@
     <UseWPF>true</UseWPF>
     <AssemblyName>dcs-insight</AssemblyName>
     <Version>1.0.0</Version>
-    <AssemblyVersion>1.7.4</AssemblyVersion>
+    <AssemblyVersion>1.7.5</AssemblyVersion>
     <ApplicationIcon>Images\Magnifier_icon.ico</ApplicationIcon>
   </PropertyGroup>
   <ItemGroup>

--- a/src/client/DCSInsight/DCSInsight.sln.DotSettings
+++ b/src/client/DCSInsight/DCSInsight.sln.DotSettings
@@ -10,4 +10,5 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/XamlNaming/Abbreviations/=API/@EntryIndexedValue">API</s:String>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=consolas/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=DCSAPI/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=defs/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=SENDAPI/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/client/DCSInsight/JSON/DCSAPI.cs
+++ b/src/client/DCSInsight/JSON/DCSAPI.cs
@@ -28,6 +28,12 @@ namespace DCSInsight.JSON
         [JsonProperty("parameter_defs", Required = Required.Default)]
         public List<ParameterInfo> Parameters { get; set; }
 
+        [JsonProperty("error_thrown", Required = Required.Default)]
+        public bool ErrorThrown { get; set; }
+
+        [JsonProperty("error_message", Required = Required.Default)]
+        public string ErrorMessage { get; set; }
+
         [JsonProperty("result", Required = Required.Default)]
         public string Result { get; set; }
     }

--- a/src/client/DCSInsight/MainWindow.xaml.cs
+++ b/src/client/DCSInsight/MainWindow.xaml.cs
@@ -33,8 +33,7 @@ namespace DCSInsight
         private bool _formLoaded;
         private TCPClientHandler _tcpClientHandler;
         private bool _isConnected;
-        private bool _rangeTesting;
-
+        private WindowRangeTest _windowRangeTest;
 
         public MainWindow()
         {
@@ -46,6 +45,7 @@ namespace DCSInsight
 
         public void Dispose()
         {
+            _windowRangeTest?.Close();
             ICEventHandler.DetachErrorListener(this);
             ICEventHandler.DetachConnectionListener(this);
             ICEventHandler.DetachDataListener(this);
@@ -145,12 +145,12 @@ namespace DCSInsight
                 Dispatcher?.BeginInvoke((Action)(() => Common.ShowErrorMessageBox(ex)));
             }
         }
-        
+
         public void ErrorMessage(ErrorEventArgs args)
         {
             try
             {
-                if (_rangeTesting) return;
+                if (_windowRangeTest != null) return;
 
                 Logger.Error(args.Ex);
                 Dispatcher?.BeginInvoke((Action)(() => TextBlockMessage.Text = $"{args.Message}. See log file."));
@@ -165,7 +165,7 @@ namespace DCSInsight
         {
             try
             {
-                if (_rangeTesting) return;
+                if (_windowRangeTest != null) return;
 
                 if (args.DCSAPIS != null)
                 {
@@ -224,7 +224,7 @@ namespace DCSInsight
                 Dispatcher?.BeginInvoke((Action)(() => Common.ShowErrorMessageBox(ex)));
             }
         }
-        
+
         private void ButtonConnect_OnClick(object sender, RoutedEventArgs e)
         {
             try
@@ -487,16 +487,8 @@ namespace DCSInsight
         {
             try
             {
-                try
-                {
-                    _rangeTesting = true;
-                    var windowRangeTest = new WindowRangeTest(_dcsAPIList);
-                    windowRangeTest.ShowDialog();
-                }
-                finally
-                {
-                    _rangeTesting = false;
-                }
+                _windowRangeTest = new WindowRangeTest(_dcsAPIList);
+                _windowRangeTest.Show();
             }
             catch (Exception ex)
             {

--- a/src/client/DCSInsight/Misc/ResultComparator.cs
+++ b/src/client/DCSInsight/Misc/ResultComparator.cs
@@ -92,11 +92,26 @@ namespace DCSInsight.Misc
                     currentTestString.Append($"{dcsApiParameter.ParameterName} [{dcsApiParameter.Value}], ");
                 }
 
-                currentTestString.Append($" result : {_dcsApi.Result}\n");
+                currentTestString.Append($" result : {(string.IsNullOrEmpty(_dcsApi.Result) ? "nil" : _dcsApi.Result)}");
 
                 return currentTestString.ToString();
             }
         }
+
+        public static string GetResultString(DCSAPI dcsApi)
+        {
+            var currentTestString = new StringBuilder();
+
+            foreach (var dcsApiParameter in dcsApi.Parameters)
+            {
+                currentTestString.Append($"{dcsApiParameter.ParameterName} [{dcsApiParameter.Value}], ");
+            }
+
+            currentTestString.Append($" result : {dcsApi.Result}");
+
+            return currentTestString.ToString();
+        }
+
 
         public static void SetDecimals(bool limitDecimals, int decimalPlaces)
         {

--- a/src/client/DCSInsight/UserControls/UserControlAPI.xaml.cs
+++ b/src/client/DCSInsight/UserControls/UserControlAPI.xaml.cs
@@ -242,13 +242,15 @@ namespace DCSInsight.UserControls
         {
             try
             {
+                var result = dcsApi.ErrorThrown ? dcsApi.ErrorMessage : (string.IsNullOrEmpty(dcsApi.Result) ? "nil" : dcsApi.Result);
+
                 if (_keepResults)
                 {
                     Dispatcher?.BeginInvoke((Action)(() => TextBoxResult.Text = TextBoxResult.Text.Insert(0, "\n-----------\n")));
-                    Dispatcher?.BeginInvoke((Action)(() => TextBoxResult.Text = TextBoxResult.Text.Insert(0, dcsApi.Result)));
+                    Dispatcher?.BeginInvoke((Action)(() => TextBoxResult.Text = TextBoxResult.Text.Insert(0, result)));
                     return;
                 }
-                Dispatcher?.BeginInvoke((Action)(() => TextBoxResult.Text = dcsApi.Result));
+                Dispatcher?.BeginInvoke((Action)(() => TextBoxResult.Text = result));
             }
             catch (Exception ex)
             {

--- a/src/client/DCSInsight/Windows/WindowRangeTest.xaml
+++ b/src/client/DCSInsight/Windows/WindowRangeTest.xaml
@@ -13,6 +13,7 @@
         </Grid.ColumnDefinitions>
         <Grid.RowDefinitions>
             <RowDefinition Height="35" />
+            <RowDefinition Height="35" />
             <RowDefinition Height="10*" />
             <RowDefinition Height="25" />
         </Grid.RowDefinitions>
@@ -23,11 +24,16 @@
             <Button  Content="Start" Width="50" Margin="10,0,0,0" BorderBrush="Gray" FontSize="14" Name="ButtonStart"  Click="ButtonStart_OnClick"></Button>
             <Button  Content="Stop" Width="50" Margin="10,0,0,0" BorderBrush="Gray" FontSize="14" Name="ButtonStop"  Click="ButtonStop_OnClick"></Button>
             <userControls:UserControlPulseLED x:Name="PulseLed" Margin="10,0,0,0"/>
+            <CheckBox Name="CheckBoxTop" Content="On Top" BorderBrush="Gray" Margin="20,0,0,0" Checked="CheckBoxTop_OnChecked" Unchecked="CheckBoxTop_OnUnchecked"></CheckBox>
+            <Button Width="20" Content="?" Margin="10,0,0,0" BorderBrush="Black" FontSize="14" Name="ButtonInformation"  Click="ButtonInformation_OnClick"></Button>
+        </ToolBar>
+
+        <ToolBar Height="35" HorizontalAlignment="Stretch" Name="ToolBarMain2" VerticalAlignment="Top" Grid.Column="0" Grid.Row="1">
             <Label VerticalAlignment="Center" Content="Loop"  Margin="10,0,0,0" />
             <Label VerticalAlignment="Center" Margin="0,0,0,0" >
                 <CheckBox Name="CheckBoxLoop" VerticalAlignment="Center" IsChecked="False" Checked="CheckBoxLoop_OnChecked" Unchecked="CheckBoxLoop_OnUnchecked"/>
             </Label>
-            <Label VerticalAlignment="Center" Content="Changes only"  Margin="10,0,0,0" />
+            <Label VerticalAlignment="Center" Content="Show Changes Only"  Margin="10,0,0,0" />
             <Label VerticalAlignment="Center" Margin="0,0,0,0" >
                 <CheckBox Name="CheckBoxShowChangesOnly" VerticalAlignment="Center" IsChecked="False" Checked="CheckBoxShowChangesOnly_OnChecked" Unchecked="CheckBoxShowChangesOnly_OnUnchecked"/>
             </Label>
@@ -41,11 +47,17 @@
                 <ComboBoxItem>4</ComboBoxItem>
                 <ComboBoxItem>5</ComboBoxItem>
             </ComboBox>
-            <CheckBox Name="CheckBoxTop" Content="On Top" BorderBrush="Gray" Margin="20,0,0,0" Checked="CheckBoxTop_OnChecked" Unchecked="CheckBoxTop_OnUnchecked"></CheckBox>
-            <Button Width="20" Content="?" Margin="10,0,0,0" BorderBrush="Black" FontSize="14" Name="ButtonInformation"  Click="ButtonInformation_OnClick"></Button>
+            <Label VerticalAlignment="Center" Content="Show Errors"  Margin="10,0,0,0" />
+            <Label VerticalAlignment="Center" Margin="0,0,0,0" >
+                <CheckBox Name="CheckBoxShowErrors" VerticalAlignment="Center" IsChecked="False" Checked="CheckBoxShowErrors_OnChecked" Unchecked="CheckBoxShowErrors_OnUnchecked"/>
+            </Label>
+            <Label VerticalAlignment="Center" Content="Show nil Results"  Margin="10,0,0,0" />
+            <Label VerticalAlignment="Center" Margin="0,0,0,0" >
+                <CheckBox Name="CheckBoxShowNilResults" VerticalAlignment="Center" IsChecked="False" Checked="CheckBoxShowNilResults_OnChecked" Unchecked="CheckBoxShowNilResults_OnUnchecked"/>
+            </Label>
         </ToolBar>
 
-        <StackPanel Grid.Row="1" Grid.Column="0" Margin="5,5,5,5" >
+        <StackPanel Grid.Row="2" Grid.Column="0" Margin="5,5,5,5" >
             <StackPanel Name="StackPanelParameters" ></StackPanel>
             <StackPanel>
                 <TextBox Name="TextBoxResults" IsReadOnly="True" HorizontalScrollBarVisibility="Auto"  VerticalScrollBarVisibility="Visible" MaxHeight="400" />

--- a/src/server/Scripts/DCS-INSIGHT/lib/APIHandler.lua
+++ b/src/server/Scripts/DCS-INSIGHT/lib/APIHandler.lua
@@ -212,15 +212,21 @@ function APIHandler:execute(api)
 		if api.id == v.id then
 			local result_code, result = pcall(v.execute, v, api) -- = v:execute(api)
 			if result_code == true then
+				result.error_thrown = false
+				result.error_message = ""
 				return result
 			else
 				if result == nil then
-					api.result = "Error but no error message"
+					api.error_thrown = true
+					api.error_message = "Error but no error message"
+					api.result = nil
 					return api
 				else
 					local path = v:script_path():gsub("%-", "%%-") -- escape any hyphen otherwise next gsub won't work
-					Log:log(result:gsub(path, ""))
-					api.result = result:gsub(path, "")
+					--Log:log(result:gsub(path, ""))
+					api.error_thrown = true
+					api.result = nil
+					api.error_message = result:gsub(path, "")
 					return api
 				end
 			end

--- a/src/server/Scripts/DCS-INSIGHT/lib/commands/GetArgumentValue.lua
+++ b/src/server/Scripts/DCS-INSIGHT/lib/commands/GetArgumentValue.lua
@@ -33,7 +33,8 @@ function GetArgumentValue:init() end
 function GetArgumentValue:execute(api)
 	local result_code, message = self:verify_params()
 	if result_code == 1 then
-		api.result = message
+		api.error_thrown = true
+		api.error_message = message
 		return api
 	end
 
@@ -48,7 +49,8 @@ function GetArgumentValue:execute(api)
 	end
 
 	if self:verify_device(param0) == false then
-		api.result = "Device not found"
+		api.error_thrown = true
+		api.error_message = "Device not found"
 		return api
 	end
 

--- a/src/server/Scripts/DCS-INSIGHT/lib/commands/GetFrequency.lua
+++ b/src/server/Scripts/DCS-INSIGHT/lib/commands/GetFrequency.lua
@@ -34,7 +34,8 @@ function GetFrequency:execute(api)
 
 	local result_code, message = self:verify_params()
 	if result_code == 1 then
-		api.result = message
+		api.error_thrown = true
+		api.error_message = message
 		return api
 	end
 
@@ -45,7 +46,8 @@ function GetFrequency:execute(api)
 	end
 
 	if self:verify_device(param0) == false then
-		api.result = "Device not found"
+		api.error_thrown = true
+		api.error_message = "Device not found"
 		return api
 	end
 

--- a/src/server/Scripts/DCS-INSIGHT/lib/commands/ListIndicationAPI.lua
+++ b/src/server/Scripts/DCS-INSIGHT/lib/commands/ListIndicationAPI.lua
@@ -31,7 +31,8 @@ function ListIndicationAPI:init() end
 function ListIndicationAPI:execute(api)
 	local result_code, message = self:verify_params()
 	if result_code == 1 then
-		api.result = message
+		api.error_thrown = true
+		api.error_message = message
 		return api
 	end
 

--- a/src/server/Scripts/DCS-INSIGHT/lib/commands/LoGetADIPitchBankYawAPI.lua
+++ b/src/server/Scripts/DCS-INSIGHT/lib/commands/LoGetADIPitchBankYawAPI.lua
@@ -27,7 +27,8 @@ function LoGetADIPitchBankYawAPI:init() end
 function LoGetADIPitchBankYawAPI:execute(api)
 	local result_code, message = self:verify_params()
 	if result_code == 1 then
-		api.result = message
+		api.error_thrown = true
+		api.error_message = message
 		return api
 	end
 

--- a/src/server/Scripts/DCS-INSIGHT/lib/commands/LoGetAccelerationUnitsAPI.lua
+++ b/src/server/Scripts/DCS-INSIGHT/lib/commands/LoGetAccelerationUnitsAPI.lua
@@ -27,7 +27,8 @@ function LoGetAccelerationUnitsAPI:init() end
 function LoGetAccelerationUnitsAPI:execute(api)
 	local result_code, message = self:verify_params()
 	if result_code == 1 then
-		api.result = message
+		api.error_thrown = true
+		api.error_message = message
 		return api
 	end
 

--- a/src/server/Scripts/DCS-INSIGHT/lib/commands/LoGetAircraftDrawArgumentValueAPI.lua
+++ b/src/server/Scripts/DCS-INSIGHT/lib/commands/LoGetAircraftDrawArgumentValueAPI.lua
@@ -31,7 +31,8 @@ function LoGetAircraftDrawArgumentValueAPI:init() end
 function LoGetAircraftDrawArgumentValueAPI:execute(api)
 	local result_code, message = self:verify_params()
 	if result_code == 1 then
-		api.result = message
+		api.error_thrown = true
+		api.error_message = message
 		return api
 	end
 

--- a/src/server/Scripts/DCS-INSIGHT/lib/commands/LoGetAltitudeAboveGroundLevelAPI.lua
+++ b/src/server/Scripts/DCS-INSIGHT/lib/commands/LoGetAltitudeAboveGroundLevelAPI.lua
@@ -27,7 +27,8 @@ function LoGetAltitudeAboveGroundLevelAPI:init() end
 function LoGetAltitudeAboveGroundLevelAPI:execute(api)
 	local result_code, message = self:verify_params()
 	if result_code == 1 then
-		api.result = message
+		api.error_thrown = true
+		api.error_message = message
 		return api
 	end
 

--- a/src/server/Scripts/DCS-INSIGHT/lib/commands/LoGetAltitudeAboveSeaLevelAPI.lua
+++ b/src/server/Scripts/DCS-INSIGHT/lib/commands/LoGetAltitudeAboveSeaLevelAPI.lua
@@ -27,7 +27,8 @@ function LoGetAltitudeAboveSeaLevelAPI:init() end
 function LoGetAltitudeAboveSeaLevelAPI:execute(api)
 	local result_code, message = self:verify_params()
 	if result_code == 1 then
-		api.result = message
+		api.error_thrown = true
+		api.error_message = message
 		return api
 	end
 

--- a/src/server/Scripts/DCS-INSIGHT/lib/commands/LoGetAngleOfAttackAPI.lua
+++ b/src/server/Scripts/DCS-INSIGHT/lib/commands/LoGetAngleOfAttackAPI.lua
@@ -27,7 +27,8 @@ function LoGetAngleOfAttackAPI:init() end
 function LoGetAngleOfAttackAPI:execute(api)
 	local result_code, message = self:verify_params()
 	if result_code == 1 then
-		api.result = message
+		api.error_thrown = true
+		api.error_message = message
 		return api
 	end
 

--- a/src/server/Scripts/DCS-INSIGHT/lib/commands/LoGetBasicAtmospherePressureAPI.lua
+++ b/src/server/Scripts/DCS-INSIGHT/lib/commands/LoGetBasicAtmospherePressureAPI.lua
@@ -27,7 +27,8 @@ function LoGetBasicAtmospherePressureAPI:init() end
 function LoGetBasicAtmospherePressureAPI:execute(api)
 	local result_code, message = self:verify_params()
 	if result_code == 1 then
-		api.result = message
+		api.error_thrown = true
+		api.error_message = message
 		return api
 	end
 

--- a/src/server/Scripts/DCS-INSIGHT/lib/commands/LoGetControlPanel_HSI_API.lua
+++ b/src/server/Scripts/DCS-INSIGHT/lib/commands/LoGetControlPanel_HSI_API.lua
@@ -27,7 +27,8 @@ function LoGetControlPanel_HSI_API:init() end
 function LoGetControlPanel_HSI_API:execute(api)
 	local result_code, message = self:verify_params()
 	if result_code == 1 then
-		api.result = message
+		api.error_thrown = true
+		api.error_message = message
 		return api
 	end
 

--- a/src/server/Scripts/DCS-INSIGHT/lib/commands/LoGetEngineInfoAPI.lua
+++ b/src/server/Scripts/DCS-INSIGHT/lib/commands/LoGetEngineInfoAPI.lua
@@ -27,7 +27,8 @@ function LoGetEngineInfoAPI:init() end
 function LoGetEngineInfoAPI:execute(api)
 	local result_code, message = self:verify_params()
 	if result_code == 1 then
-		api.result = message
+		api.error_thrown = true
+		api.error_message = message
 		return api
 	end
 

--- a/src/server/Scripts/DCS-INSIGHT/lib/commands/LoGetGlideDeviationAPI.lua
+++ b/src/server/Scripts/DCS-INSIGHT/lib/commands/LoGetGlideDeviationAPI.lua
@@ -27,7 +27,8 @@ function LoGetGlideDeviationAPI:init() end
 function LoGetGlideDeviationAPI:execute(api)
 	local result_code, message = self:verify_params()
 	if result_code == 1 then
-		api.result = message
+		api.error_thrown = true
+		api.error_message = message
 		return api
 	end
 

--- a/src/server/Scripts/DCS-INSIGHT/lib/commands/LoGetIndicatedAirSpeedAPI.lua
+++ b/src/server/Scripts/DCS-INSIGHT/lib/commands/LoGetIndicatedAirSpeedAPI.lua
@@ -27,7 +27,8 @@ function LoGetIndicatedAirSpeedAPI:init() end
 function LoGetIndicatedAirSpeedAPI:execute(api)
 	local result_code, message = self:verify_params()
 	if result_code == 1 then
-		api.result = message
+		api.error_thrown = true
+		api.error_message = message
 		return api
 	end
 

--- a/src/server/Scripts/DCS-INSIGHT/lib/commands/LoGetMCPStateAPI.lua
+++ b/src/server/Scripts/DCS-INSIGHT/lib/commands/LoGetMCPStateAPI.lua
@@ -27,7 +27,8 @@ function LoGetMCPStateAPI:init() end
 function LoGetMCPStateAPI:execute(api)
 	local result_code, message = self:verify_params()
 	if result_code == 1 then
-		api.result = message
+		api.error_thrown = true
+		api.error_message = message
 		return api
 	end
 

--- a/src/server/Scripts/DCS-INSIGHT/lib/commands/LoGetMachNumberAPI.lua
+++ b/src/server/Scripts/DCS-INSIGHT/lib/commands/LoGetMachNumberAPI.lua
@@ -27,7 +27,8 @@ function LoGetMachNumberAPI:init() end
 function LoGetMachNumberAPI:execute(api)
 	local result_code, message = self:verify_params()
 	if result_code == 1 then
-		api.result = message
+		api.error_thrown = true
+		api.error_message = message
 		return api
 	end
 

--- a/src/server/Scripts/DCS-INSIGHT/lib/commands/LoGetMagneticYawAPI.lua
+++ b/src/server/Scripts/DCS-INSIGHT/lib/commands/LoGetMagneticYawAPI.lua
@@ -27,7 +27,8 @@ function LoGetMagneticYawAPI:init() end
 function LoGetMagneticYawAPI:execute(api)
 	local result_code, message = self:verify_params()
 	if result_code == 1 then
-		api.result = message
+		api.error_thrown = true
+		api.error_message = message
 		return api
 	end
 

--- a/src/server/Scripts/DCS-INSIGHT/lib/commands/LoGetMechInfoAPI.lua
+++ b/src/server/Scripts/DCS-INSIGHT/lib/commands/LoGetMechInfoAPI.lua
@@ -27,7 +27,8 @@ function LoGetMechInfoAPI:init() end
 function LoGetMechInfoAPI:execute(api)
 	local result_code, message = self:verify_params()
 	if result_code == 1 then
-		api.result = message
+		api.error_thrown = true
+		api.error_message = message
 		return api
 	end
 

--- a/src/server/Scripts/DCS-INSIGHT/lib/commands/LoGetMissionStartTimeAPI.lua
+++ b/src/server/Scripts/DCS-INSIGHT/lib/commands/LoGetMissionStartTimeAPI.lua
@@ -27,7 +27,8 @@ function LoGetMissionStartTimeAPI:init() end
 function LoGetMissionStartTimeAPI:execute(api)
 	local result_code, message = self:verify_params()
 	if result_code == 1 then
-		api.result = message
+		api.error_thrown = true
+		api.error_message = message
 		return api
 	end
 

--- a/src/server/Scripts/DCS-INSIGHT/lib/commands/LoGetModelTimeAPI.lua
+++ b/src/server/Scripts/DCS-INSIGHT/lib/commands/LoGetModelTimeAPI.lua
@@ -27,7 +27,8 @@ function LoGetModelTimeAPI:init() end
 function LoGetModelTimeAPI:execute(api)
 	local result_code, message = self:verify_params()
 	if result_code == 1 then
-		api.result = message
+		api.error_thrown = true
+		api.error_message = message
 		return api
 	end
 

--- a/src/server/Scripts/DCS-INSIGHT/lib/commands/LoGetNavigationInfoAPI.lua
+++ b/src/server/Scripts/DCS-INSIGHT/lib/commands/LoGetNavigationInfoAPI.lua
@@ -27,7 +27,8 @@ function LoGetNavigationInfoAPI:init() end
 function LoGetNavigationInfoAPI:execute(api)
 	local result_code, message = self:verify_params()
 	if result_code == 1 then
-		api.result = message
+		api.error_thrown = true
+		api.error_message = message
 		return api
 	end
 

--- a/src/server/Scripts/DCS-INSIGHT/lib/commands/LoGetPayloadInfoAPI.lua
+++ b/src/server/Scripts/DCS-INSIGHT/lib/commands/LoGetPayloadInfoAPI.lua
@@ -27,7 +27,8 @@ function LoGetPayloadInfoAPI:init() end
 function LoGetPayloadInfoAPI:execute(api)
 	local result_code, message = self:verify_params()
 	if result_code == 1 then
-		api.result = message
+		api.error_thrown = true
+		api.error_message = message
 		return api
 	end
 

--- a/src/server/Scripts/DCS-INSIGHT/lib/commands/LoGetPilotNameAPI.lua
+++ b/src/server/Scripts/DCS-INSIGHT/lib/commands/LoGetPilotNameAPI.lua
@@ -27,7 +27,8 @@ function LoGetPilotNameAPI:init() end
 function LoGetPilotNameAPI:execute(api)
 	local result_code, message = self:verify_params()
 	if result_code == 1 then
-		api.result = message
+		api.error_thrown = true
+		api.error_message = message
 		return api
 	end
 

--- a/src/server/Scripts/DCS-INSIGHT/lib/commands/LoGetSelfDataAPI.lua
+++ b/src/server/Scripts/DCS-INSIGHT/lib/commands/LoGetSelfDataAPI.lua
@@ -27,7 +27,8 @@ function LoGetSelfDataAPI:init() end
 function LoGetSelfDataAPI:execute(api)
 	local result_code, message = self:verify_params()
 	if result_code == 1 then
-		api.result = message
+		api.error_thrown = true
+		api.error_message = message
 		return api
 	end
 

--- a/src/server/Scripts/DCS-INSIGHT/lib/commands/LoGetSideDeviationAPI.lua
+++ b/src/server/Scripts/DCS-INSIGHT/lib/commands/LoGetSideDeviationAPI.lua
@@ -27,7 +27,8 @@ function LoGetSideDeviationAPI:init() end
 function LoGetSideDeviationAPI:execute(api)
 	local result_code, message = self:verify_params()
 	if result_code == 1 then
-		api.result = message
+		api.error_thrown = true
+		api.error_message = message
 		return api
 	end
 

--- a/src/server/Scripts/DCS-INSIGHT/lib/commands/LoGetSlipBallPositionAPI.lua
+++ b/src/server/Scripts/DCS-INSIGHT/lib/commands/LoGetSlipBallPositionAPI.lua
@@ -27,7 +27,8 @@ function LoGetSlipBallPositionAPI:init() end
 function LoGetSlipBallPositionAPI:execute(api)
 	local result_code, message = self:verify_params()
 	if result_code == 1 then
-		api.result = message
+		api.error_thrown = true
+		api.error_message = message
 		return api
 	end
 

--- a/src/server/Scripts/DCS-INSIGHT/lib/commands/LoGetSnaresAPI.lua
+++ b/src/server/Scripts/DCS-INSIGHT/lib/commands/LoGetSnaresAPI.lua
@@ -27,7 +27,8 @@ function LoGetSnaresAPI:init() end
 function LoGetSnaresAPI:execute(api)
 	local result_code, message = self:verify_params()
 	if result_code == 1 then
-		api.result = message
+		api.error_thrown = true
+		api.error_message = message
 		return api
 	end
 

--- a/src/server/Scripts/DCS-INSIGHT/lib/commands/LoGetTWSInfoAPI.lua
+++ b/src/server/Scripts/DCS-INSIGHT/lib/commands/LoGetTWSInfoAPI.lua
@@ -27,7 +27,8 @@ function LoGetTWSInfoAPI:init() end
 function LoGetTWSInfoAPI:execute(api)
 	local result_code, message = self:verify_params()
 	if result_code == 1 then
-		api.result = message
+		api.error_thrown = true
+		api.error_message = message
 		return api
 	end
 

--- a/src/server/Scripts/DCS-INSIGHT/lib/commands/LoGetTrueAirSpeedAPI.lua
+++ b/src/server/Scripts/DCS-INSIGHT/lib/commands/LoGetTrueAirSpeedAPI.lua
@@ -27,7 +27,8 @@ function LoGetTrueAirSpeedAPI:init() end
 function LoGetTrueAirSpeedAPI:execute(api)
 	local result_code, message = self:verify_params()
 	if result_code == 1 then
-		api.result = message
+		api.error_thrown = true
+		api.error_message = message
 		return api
 	end
 

--- a/src/server/Scripts/DCS-INSIGHT/lib/commands/LoGetVerticalVelocityAPI.lua
+++ b/src/server/Scripts/DCS-INSIGHT/lib/commands/LoGetVerticalVelocityAPI.lua
@@ -27,7 +27,8 @@ function LoGetVerticalVelocityAPI:init() end
 function LoGetVerticalVelocityAPI:execute(api)
 	local result_code, message = self:verify_params()
 	if result_code == 1 then
-		api.result = message
+		api.error_thrown = true
+		api.error_message = message
 		return api
 	end
 

--- a/src/server/Scripts/DCS-INSIGHT/lib/commands/LoIsOwnshipExportAllowedAPI.lua
+++ b/src/server/Scripts/DCS-INSIGHT/lib/commands/LoIsOwnshipExportAllowedAPI.lua
@@ -27,7 +27,8 @@ function LoIsOwnshipExportAllowedAPI:init() end
 function LoIsOwnshipExportAllowedAPI:execute(api)
 	local result_code, message = self:verify_params()
 	if result_code == 1 then
-		api.result = message
+		api.error_thrown = true
+		api.error_message = message
 		return api
 	end
 

--- a/src/server/Scripts/DCS-INSIGHT/lib/commands/PerformClickableAction.lua
+++ b/src/server/Scripts/DCS-INSIGHT/lib/commands/PerformClickableAction.lua
@@ -37,7 +37,8 @@ function PerformClickableAction:execute(api)
 
 	local result_code, message = self:verify_params()
 	if result_code == 1 then
-		api.result = message
+		api.error_thrown = true
+		api.error_message = message
 		return api
 	end
 
@@ -54,7 +55,8 @@ function PerformClickableAction:execute(api)
 	end
 
 	if self:verify_device(param0) == false then
-		api.result = "Device not found"
+		api.error_thrown = true
+		api.error_message = "Device not found"
 		return api
 	end
 

--- a/src/server/Scripts/DCS-INSIGHT/lib/commands/SetArgumentValue.lua
+++ b/src/server/Scripts/DCS-INSIGHT/lib/commands/SetArgumentValue.lua
@@ -37,7 +37,8 @@ function SetArgumentValue:execute(api)
 
 	local result_code, message = self:verify_params()
 	if result_code == 1 then
-		api.result = message
+		api.error_thrown = true
+		api.error_message = message
 		return api
 	end
 
@@ -54,7 +55,8 @@ function SetArgumentValue:execute(api)
 	end
 
 	if self:verify_device(param0) == false then
-		api.result = "Device not found"
+		api.error_thrown = true
+		api.error_message = "Device not found"
 		return api
 	end
 

--- a/src/server/Scripts/DCS-INSIGHT/lib/commands/SetCommand.lua
+++ b/src/server/Scripts/DCS-INSIGHT/lib/commands/SetCommand.lua
@@ -37,7 +37,8 @@ function SetCommand:execute(api)
 
 	local result_code, message = self:verify_params()
 	if result_code == 1 then
-		api.result = message
+		api.error_thrown = true
+		api.error_message = message
 		return api
 	end
 
@@ -54,7 +55,8 @@ function SetCommand:execute(api)
 	end
 
 	if self:verify_device(param0) == false then
-		api.result = "Device not found"
+		api.error_thrown = true
+		api.error_message = "Device not found"
 		return api
 	end
 

--- a/src/server/Scripts/DCS-INSIGHT/lib/commands/SetFrequency.lua
+++ b/src/server/Scripts/DCS-INSIGHT/lib/commands/SetFrequency.lua
@@ -36,7 +36,8 @@ function SetFrequency:execute(api)
 
 	local result_code, message = self:verify_params()
 	if result_code == 1 then
-		api.result = message
+		api.error_thrown = true
+		api.error_message = message
 		return api
 	end
 
@@ -50,7 +51,8 @@ function SetFrequency:execute(api)
 	end
 
 	if self:verify_device(param0) == false then
-		api.result = "Device not found"
+		api.error_thrown = true
+		api.error_message = "Device not found"
 		return api
 	end
 

--- a/src/server/Scripts/DCS-INSIGHT/lib/commands/common/APIInfo.lua
+++ b/src/server/Scripts/DCS-INSIGHT/lib/commands/common/APIInfo.lua
@@ -8,12 +8,13 @@ local Parameter = require("Scripts.DCS-INSIGHT.lib.commands.common.Parameter")
 --- @field api_syntax string
 --- @field parameter_count number
 --- @field parameter_defs table<APIParameter>
---- @field value any
+--- @field error_thrown boolean
+--- @field error_message string
 --- @field result any
 local APIInfo = {}
 
 --- Constructs a new APIInfo
-function APIInfo:new(id, returns_data, api_syntax, parameter_count, parameter_defs, value, result)
+function APIInfo:new(id, returns_data, api_syntax, parameter_count, parameter_defs, error_thrown, error_message, result)
 	--- @type APIInfo
 	local o = {
 		id = id,
@@ -21,7 +22,8 @@ function APIInfo:new(id, returns_data, api_syntax, parameter_count, parameter_de
 		api_syntax = api_syntax,
 		parameter_count = parameter_count,
 		parameter_defs = parameter_defs or {},
-		value = value,
+		error_thrown = false,
+		error_message = "",
 		result = result,
 	}
 	setmetatable(o, self)


### PR DESCRIPTION
* Server : Error messages are returned in its own field now with a field indicating whether error was thrown
* Client : Possibility to not show error messages or nil results during range testing. This is useful if you are testing large ranges.